### PR TITLE
 use variable ServerAddr for request header host instead 'localhost'

### DIFF
--- a/lib/Test/Nginx/Socket.pm
+++ b/lib/Test/Nginx/Socket.pm
@@ -25,6 +25,8 @@ use Test::Nginx::Util qw(
   no_long_string
   $ServerAddr
   server_addr
+  $ServerName
+  server_name
   parse_time
   $UseStap
   verbose
@@ -81,7 +83,7 @@ our @EXPORT = qw( plan run_tests run_test
   master_process_enabled
   no_long_string workers master_on master_off
   log_level no_shuffle no_root_location
-  server_addr server_root html_dir server_port server_port_for_client
+  server_addr server_root html_dir server_port server_port_for_client server_name
   timeout no_nginx_manager check_accum_error_log
 );
 
@@ -301,7 +303,7 @@ sub build_request_from_packets($$$$$) {
     $parsed_req->{method} .= ' ';
     $parsed_req->{url} .= ' ';
     $parsed_req->{http_ver} .= "\r\n";
-    $parsed_req->{headers} = "Host: $ServerAddr\r\nConnection: $conn_header\r\n$more_headers$len_header\r\n";
+    $parsed_req->{headers} = "Host: $ServerName\r\nConnection: $conn_header\r\n$more_headers$len_header\r\n";
 
     #  Get the moves from parsing
     my @elements_moves = get_moves($parsed_req);
@@ -1701,7 +1703,7 @@ sub gen_cmd_from_req ($$) {
             my $headers = $1;
             #warn "raw headers: $headers\n";
             @headers = grep {
-                !/^Connection\s*:/i && !/^Host: $ServerAddr$/i
+                !/^Connection\s*:/i && !/^Host: $ServerName$/i
                     && !/^Content-Length\s*:/i
             } split /\r\n/, $headers;
 
@@ -1756,7 +1758,7 @@ sub gen_cmd_from_req ($$) {
 
     my $link;
     {
-        my $server = $ServerAddr;
+        my $server = $ServerName;
         my $port = $ServerPortForClient;
         $link = "http://$server:$port$uri";
     }

--- a/lib/Test/Nginx/Util.pm
+++ b/lib/Test/Nginx/Util.pm
@@ -59,6 +59,8 @@ our $CheckAccumErrLog = $ENV{TEST_NGINX_CHECK_ACCUM_ERR_LOG};
 
 our $ServerAddr = 'localhost';
 
+our $ServerName = 'localhost';
+
 our $StapOutFileHandle;
 
 our @RandStrAlphabet = ('A' .. 'Z', 'a' .. 'z', '0' .. '9',
@@ -134,6 +136,15 @@ sub server_addr (@) {
     }
     else {
         return $ServerAddr;
+    }
+}
+
+sub server_name (@) {
+    if (@_) {
+        $ServerName = shift;
+    }
+    else {
+        return $ServerName;
     }
 }
 
@@ -280,6 +291,8 @@ our @EXPORT_OK = qw(
     no_long_string
     $ServerAddr
     server_addr
+    $ServerName
+    server_name
     parse_time
     $UseStap
     verbose
@@ -718,7 +731,7 @@ $http_config
 
     server {
         listen          $ServerPort;
-        server_name     '$ServerAddr';
+        server_name     '$ServerName';
 
         client_max_body_size 30M;
         #client_body_buffer_size 4k;
@@ -748,7 +761,7 @@ _EOC_
         print $out <<_EOC_;
     server {
         listen          $ServerPort;
-        server_name     'Test-Nginx';
+        server_name     '$ServerName';
 
         location = /ver {
             return 200 '$ConfigVersion';


### PR DESCRIPTION
在用 test-nginx 测试业务逻辑代码，业务中需要同时配置多个 server，且业务代码依赖 request header 的 host

所以有了这个，还请春哥检查~~
