### PR TITLE
feature: new block "---must_die"

### DIFF
--- a/lib/Test/Nginx/Socket.pm
+++ b/lib/Test/Nginx/Socket.pm
@@ -49,6 +49,7 @@ use Test::Nginx::Util qw(
   $ServRoot
   $ConfFile
   $RunTestHelper
+  $CheckErrorLog
   $FilterHttpConfig
   $RepeatEach
   $CheckLeak
@@ -106,6 +107,7 @@ sub get_linear_regression_slope ($);
 sub value_contains ($$);
 
 $RunTestHelper = \&run_test_helper;
+$CheckErrorLog = \&check_error_log;
 
 sub set_http_config_filter ($) {
     $FilterHttpConfig = shift;
@@ -2812,6 +2814,25 @@ value. Also used when a request is split in packets.
 
 Skip the tests in the current test block in the "check leak" testing mode
 (i.e, with C<TEST_NGINX_CHECK_LEAK>=1).
+
+=head2 must_die
+
+Nginx must die right after starting. If value is set, exit value must
+match value.
+
+Normal request and response cycle is not done. But you should use
+C<error_log> to check message is as expected.
+
+This is meant to test bogus configuration is noticed and given proper
+error message. It is normal to see stderr error message when running tests.
+
+This configuration is not compatible with C<TEST_NGINX_USE_VALGRIND>
+C<TEST_NGINX_USE_STAP> or C<TEST_NGINX_CHECK_LEAK>. There is no great
+point of checking memory allocations when you expect nginx to die right
+away.  Add guards to skip these tests at testsuite.
+
+This directive is handled before checking
+C<TEST_NGINX_IGNORE_MISSING_DIRECTIVES>.
 
 =head1 Environment variables
 


### PR DESCRIPTION
Feature to test if exit value is something else than 0. Used to test
config parser can notice bogus config. If this is set, no requests
are done.

This is for #10.

I've update patch according to review from @agentzh
https://github.com/openresty/test-nginx/pull/11

In addition to previous version
- it is always failure to have coredump
- it is always failure not to be able to execute program
- supports repeat_each
- supports error_log
- handle situation where shell is used to run program
