### PR TITLE
added perl_require and perl_modules

### DIFF
--- a/lib/Test/Nginx/LWP.pm
+++ b/lib/Test/Nginx/LWP.pm
@@ -36,6 +36,8 @@ use Test::Nginx::Util qw(
     repeat_each
     no_shuffle
     no_root_location
+    perl_modules
+    perl_require    
 );
 
 our $UserAgent = LWP::UserAgent->new;
@@ -47,7 +49,8 @@ $UserAgent->agent(__PACKAGE__);
 our @EXPORT = qw( plan run_tests run_test
     repeat_each config_preamble worker_connections
     master_process_enabled master_on master_off
-    no_long_string no_shuffle no_root_location);
+    no_long_string no_shuffle no_root_location
+    perl_modules perl_require);
 
 sub no_long_string () {
     $NoLongString = 1;

--- a/lib/Test/Nginx/Socket.pm
+++ b/lib/Test/Nginx/Socket.pm
@@ -70,6 +70,8 @@ use Test::Nginx::Util qw(
   server_port
   server_port_for_client
   no_nginx_manager
+  perl_modules
+  perl_require  
 );
 
 #use Smart::Comments::JSON '###';
@@ -87,6 +89,7 @@ our @EXPORT = qw( plan run_tests run_test
   server_name
   server_addr server_root html_dir server_port server_port_for_client
   timeout no_nginx_manager check_accum_error_log
+  perl_modules perl_require
 );
 
 our $TotalConnectingTimeouts = 0;

--- a/lib/Test/Nginx/Util.pm
+++ b/lib/Test/Nginx/Util.pm
@@ -339,6 +339,8 @@ our @EXPORT_OK = qw(
     server_port
     server_port_for_client
     no_nginx_manager
+    perl_modules
+    perl_require
 );
 
 
@@ -351,6 +353,18 @@ our $ConfigPreamble = '';
 
 sub config_preamble ($) {
     $ConfigPreamble = shift;
+}
+
+our $PerlModules = '';
+
+sub perl_modules ($) {
+    $PerlModules = shift;
+}
+
+our $PerlRequire = '';
+
+sub perl_require ($) {
+    $PerlRequire = shift;
 }
 
 our $RunTestHelper;
@@ -731,6 +745,9 @@ http {
     keepalive_timeout  68;
 
 $http_config
+
+    $PerlModules
+    $PerlRequire
 
     server {
         listen          $ServerPort;


### PR DESCRIPTION
Added two new directives to be used with http://nginx.org/en/docs/http/ngx_http_perl_module.html: perl_modules and perl_require

Example:
use Test::Nginx::Socket;

perl_modules("perl_modules /home/irocha/perl/nginx;");
perl_require("perl_require test.pm;");

repeat_each(1);
plan tests => $Test::Nginx::Socket::RepeatEach \* 2 \* blocks();
$ENV{TEST_NGINX_ERROR_LOG} = "/tmp/test.log";
log_level('warn');
run_tests();
