### PR TITLE
drop num-callers to 50 as it is limited by valgrind-3.7.0

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Changes for Test::Nginx
 
+master - 2014-08-08
+ *   change: set --num-callers=50 to valgrind by default
+
 0.23 - 2014-04-05
  *   feature: added new section --- response_body_unlike. thanks
      Rickey Visinski for the patch.

--- a/lib/Test/Nginx/Util.pm
+++ b/lib/Test/Nginx/Util.pm
@@ -1362,9 +1362,9 @@ start_nginx:
                     $opts = "--tool=memcheck --leak-check=full --show-possibly-lost=no";
 
                     if (-f 'valgrind.suppress') {
-                        $cmd = "valgrind --num-callers=100 -q $opts --gen-suppressions=all --suppressions=valgrind.suppress $cmd";
+                        $cmd = "valgrind --num-callers=50 -q $opts --gen-suppressions=all --suppressions=valgrind.suppress $cmd";
                     } else {
-                        $cmd = "valgrind --num-callers=100 -q $opts --gen-suppressions=all $cmd";
+                        $cmd = "valgrind --num-callers=50 -q $opts --gen-suppressions=all $cmd";
                     }
 
                 } else {


### PR DESCRIPTION
Fix for issue https://github.com/openresty/test-nginx/issues/16
