### PR TITLE
todo feature

### DIFF
--- a/lib/Test/Nginx/Socket.pm
+++ b/lib/Test/Nginx/Socket.pm
@@ -2954,6 +2954,19 @@ For example:
     --- skip_nginx2
     2: < 0.8.53 and >= 0.8.41
 
+=head2 todo
+
+Mark tests as todo. Currently they are not used but they should be.
+
+The format for this section is
+
+    --- todo
+    <subtest-count>: <reason>
+
+The <subtest-count> value must be a positive integer.
+
+<reason> is logged when you run tests with --directives.
+
 =head2 stap
 
 This section is used to specify user systemtap script file (.stp file)

--- a/lib/Test/Nginx/Util.pm
+++ b/lib/Test/Nginx/Util.pm
@@ -410,7 +410,6 @@ our $CheckErrorLog;
 
 our $NginxVersion;
 our $NginxRawVersion;
-our $TODO;
 
 sub add_block_preprocessor(&) {
     unshift @BlockPreprocessors, shift;
@@ -1321,6 +1320,22 @@ sub run_test ($) {
         }
     }
 
+    my $todo = $block->todo;
+    if (defined $todo) {
+        if ($todo =~ m{
+                ^ \s* (\d+) \s* : \s* (.*)
+            }xs)
+        {
+            $should_todo = 1;
+            $tests_to_skip = $1;
+            $todo_reason = $2;
+        } else {
+            bail_out("$name - Invalid --- todo spec: " .
+                $todo);
+            die;
+        }
+    }
+
     if (!defined $todo_reason) {
         $todo_reason = "various reasons";
     }
@@ -2148,7 +2163,7 @@ request:
 
         } elsif ($should_todo) {
             TODO: {
-                local $TODO = "$name - $todo_reason";
+                Test::More::todo_skip("$name - $todo_reason", $tests_to_skip);
 
                 $RunTestHelper->($block, $dry_run, $i - 1);
                 run_tcp_server_tests($block, $tcp_socket, $tcp_query_file);

--- a/t/todo.t
+++ b/t/todo.t
@@ -1,0 +1,15 @@
+use lib 'lib';
+use Test::Nginx::Socket;
+use Test::Nginx::Util;
+use Test::More;
+
+for (blocks()) {
+    Test::Nginx::Util::run_test($_);
+}
+
+done_testing();
+
+__DATA__
+=== todo: basic
+--- config
+--- todo: 1: reason


### PR DESCRIPTION
Implemented with todo_skip as it is not possible to use todo because
there is multiple SKIP blocks and they mess up.

As far as I could see todo_nginx did not do what I wanted, annotate failing tests and run suite just to make sure all other tests pass. After it is easy to go back by just grepping '--- todo'. And also I see todotests if I use prove --directives.

I'm not really happy with this. But it is nicer way to annotate bogus tests you might want to run in a future than using skip in various forms. This should be implemented with TODO block and $TODO variable, but that is not possible because there is multiple SKIP blocks in Test::Nginx::Socket. All SKIP blocks should be at same "level" than TODO blocks. Maybe that might be possible to do with converting SKIP blocks just update state at top level and returning from tests in normal means and then catching this state at top level.

I mainly submit this pull request to show how to implement this currently.