### PR TITLE
Extra envs to end

### DIFF
--- a/lib/Test/Nginx/Socket.pm
+++ b/lib/Test/Nginx/Socket.pm
@@ -2324,6 +2324,10 @@ DYLD_INSERT_LIBRARIES
 
 DYLD_FORCE_FLAT_NAMESPACE
 
+=item *
+
+ASAN_OPTIONS
+
 =back
 
 =head2 workers

--- a/lib/Test/Nginx/Util.pm
+++ b/lib/Test/Nginx/Util.pm
@@ -918,6 +918,7 @@ _EOC_
     print $out "}\n";
 
     print $out <<_EOC_;
+env ASAN_OPTIONS;
 _EOC_
 
     close $out;

--- a/lib/Test/Nginx/Util.pm
+++ b/lib/Test/Nginx/Util.pm
@@ -917,6 +917,9 @@ _EOC_
 
     print $out "}\n";
 
+    print $out <<_EOC_;
+_EOC_
+
     close $out;
 }
 


### PR DESCRIPTION
As https://github.com/openresty/lua-nginx-module/pull/645 I have moved ASAN_OPTIONS to end of config file. It is better to add stuff at later stages as some tests might use line numbers of config file as part of test and changeing lines is not good.

If you want to use ASAN (address sanitizer) then this patch helps. https://github.com/google/sanitizers/wiki/AddressSanitizerFlags#run-time-flags