### PR TITLE
Document default timeout value

### DIFF
--- a/lib/Test/Nginx/Socket.pm
+++ b/lib/Test/Nginx/Socket.pm
@@ -2838,6 +2838,8 @@ An optional time unit can be specified, for example,
 
 Acceptable time units are C<s> (seconds) and C<ms> (milliseconds). If no time unit is specified, then default to seconds.
 
+Default to 3s.
+
 =head2 error_log_file
 
 Specify the global error log file for the current test block only.


### PR DESCRIPTION
The documentation for the `timeout` setting doesn't say what the default value is. I had initially assumed that meant there was no default timeout value, but it actually [looks](https://github.com/openresty/test-nginx/blob/9c263518dc3a48de0c13f51ef37bd5c624134bfb/lib/Test/Nginx/Util.pm#L56) like the default timeout is 3 seconds. This just adds that tiny bit of information to the documentation.