### PR TITLE
Clarify error_log failure message

### DIFF
--- a/lib/Test/Nginx/Socket.pm
+++ b/lib/Test/Nginx/Socket.pm
@@ -1099,7 +1099,7 @@ sub check_error_log ($$$$) {
             if (defined $pat) {
                 SKIP: {
                     skip "$name - error_log - tests skipped due to $dry_run", 1 if $dry_run;
-                    fail("$name - pattern \"$pat\" matches a line in error.log (req $repeated_req_idx)");
+                    fail("$name - pattern \"$pat\" should match a line in error.log (req $repeated_req_idx)");
                     #die join("", @$lines);
                 }
             }


### PR DESCRIPTION
Currently, the failure message you receive when using the `error_log` section phrases things in a positive fashion. This might be confusing, since the message reads as though the pattern *does* match (it's also the same wording as the "pass" message). This is a tiny text tweak to clarify that the line does not match.

While I can see how the current message could be considered correct (since the overall matching is marked as failed), this personally threw me off a little bit, since the other failure messages do seem to use negative phrasing to explain what went wrong (compare the different pass/fail messages for [`no_error_log`](https://github.com/openresty/test-nginx/blob/523ee97255cd4ea06b6fdbef3635ec6fff0fd483/lib/Test/Nginx/Socket.pm#L1157-L1169) versus the identical pass/fail messages for [`error_log`](https://github.com/openresty/test-nginx/blob/523ee97255cd4ea06b6fdbef3635ec6fff0fd483/lib/Test/Nginx/Socket.pm#L1091-L1102)).

But essentially, this just changes the error message when something fails to match in `error_log` from:

```
Failed test 'TEST 1: example test - pattern "foo" matches a line in error.log (req 0)'
```

To:

```
Failed test 'TEST 1: example test - pattern "foo" does not match a line in error.log (req 0)'
```