### PR TITLE
Add ngx_shibboleth as module using test-nginx

### DIFF
--- a/lib/Test/Nginx.pm
+++ b/lib/Test/Nginx.pm
@@ -137,6 +137,10 @@ L<https://github.com/FRiCKLE/ngx_coolkit>
 
 L<http://code.google.com/p/naxsi/>
 
+=item ngx_shibboleth
+
+L<https://github.com/nginx-shib/nginx-http-shibboleth>
+
 =back
 
 =head1 SOURCE REPOSITORY


### PR DESCRIPTION
Just added testing to ngx_shibboleth using Test::Nginx.  This repo also features an example of running the Nginx tests on Travis CI.