### PR TITLE
add TEST_NGINX_ARCHIVE_PATH

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ Makefile.old
 MYMETA.json
 MYMETA.yml
 META.yml
+t/servroot
+t/archive

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,5 +25,3 @@ script:
   - perl Makefile.PL
   - make -j$(JOBS)
   - make test
-  - rm -rf t/archive t/servroot
-  - TEST_NGINX_ARCHIVE_PATH=t/servroot TEST_NGINX_SERVROOT=$(pwd)/t/archive prove -lv t/0-archive.t t/archive.t

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ addons:
   apt:
     packages:
     - cpanminus
+    - nginx
 
 language: perl
 perl:
@@ -24,3 +25,5 @@ script:
   - perl Makefile.PL
   - make -j$(JOBS)
   - make test
+  - rm -rf t/archive t/servroot
+  - TEST_NGINX_ARCHIVE_PATH=t/servroot TEST_NGINX_SERVROOT=$(pwd)/t/archive prove -lv t/0-archive.t t/archive.t

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -31,8 +31,7 @@ requires        ('File::Copy::Recursive');
 use_test_base();
 auto_install();
 
-tests('t/apply_moves.t t/check_response_body.t t/get_req_from_block.t
-t/parse_request.t t/pod-coverage.t t/pod.t t/resp_body_filters.t t/syntax.t');
+#tests('t/*.t t/*/*.t');
 
 WriteAll();
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -26,7 +26,6 @@ requires        ('List::Util');
 requires        ('Encode');
 requires        ('File::Find');
 requires        ('IO::Socket::INET');
-requires        ('File::Copy::Recursive');
 
 use_test_base();
 auto_install();

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -26,11 +26,13 @@ requires        ('List::Util');
 requires        ('Encode');
 requires        ('File::Find');
 requires        ('IO::Socket::INET');
+requires        ('File::Copy::Recursive');
 
 use_test_base();
 auto_install();
 
-#tests('t/*.t t/*/*.t');
+tests('t/apply_moves.t t/check_response_body.t t/get_req_from_block.t
+t/parse_request.t t/pod-coverage.t t/pod.t t/resp_body_filters.t t/syntax.t');
 
 WriteAll();
 

--- a/lib/Test/Nginx/Socket.pm
+++ b/lib/Test/Nginx/Socket.pm
@@ -716,6 +716,7 @@ again:
             } else {
                 ( $res, $raw_headers, $left ) = parse_response( $name, $raw_resp, $head_req );
             }
+            Test::Nginx::Util::write_response($res);
         }
 
         if (!$n) {
@@ -3254,7 +3255,7 @@ Below is an example from ngx_headers_more module's test suite:
     --- response_headers
     ! X-Foo
     --- response_body
-    x-foo: 
+    x-foo:
     --- http09
 
 =head2 ignore_response
@@ -3919,6 +3920,18 @@ cycle for C<nginx>. All logs are removed before each restart, so you can
 only see the logs for the last test run (which you usually do not control
 except if you set C<TEST_NGINX_NO_SHUFFLE=1>). With this, you accumulate
 all logs into a single file that is never cleaned up by Test::Nginx.
+
+=head2 TEST_NGINX_ARCHIVE_PATH
+
+Archive files and output of test blocks, which start up nginx server and
+run to completion, to specific path.
+
+For example,
+
+    $ TEST_NGINX_ARCHIVE_PATH=t/archive prove -lv t
+    ...
+    $ ls t/archive
+    t.0-archive.TEST_1:_create_files_to_be_archived        t.0-archive.TEST_2:_each_test_block_has_its_own_output
 
 =head2 Valgrind Integration
 

--- a/lib/Test/Nginx/Socket.pm
+++ b/lib/Test/Nginx/Socket.pm
@@ -716,7 +716,9 @@ again:
             } else {
                 ( $res, $raw_headers, $left ) = parse_response( $name, $raw_resp, $head_req );
             }
-            Test::Nginx::Util::write_response($res);
+            if ($Test::Nginx::Util::ArchivePath) {
+                Test::Nginx::Util::write_response($block, $res);
+            }
         }
 
         if (!$n) {
@@ -3255,7 +3257,7 @@ Below is an example from ngx_headers_more module's test suite:
     --- response_headers
     ! X-Foo
     --- response_body
-    x-foo:
+    x-foo: 
     --- http09
 
 =head2 ignore_response
@@ -3923,15 +3925,15 @@ all logs into a single file that is never cleaned up by Test::Nginx.
 
 =head2 TEST_NGINX_ARCHIVE_PATH
 
-Archive files and output of test blocks, which start up nginx server and
-run to completion, to specific path.
+Archive nginx configure, nginx logs, and http response output to specific path
+for test blocks start up nginx server and run to completion.
 
 For example,
 
-    $ TEST_NGINX_ARCHIVE_PATH=t/archive prove -lv t
+    $ TEST_NGINX_ARCHIVE_PATH=t/archive prove -r t
     ...
     $ ls t/archive
-    t.0-archive.TEST_1:_create_files_to_be_archived        t.0-archive.TEST_2:_each_test_block_has_its_own_output
+    t.0-archive.TEST_1_create_files_to_be_archived        t.0-archive.TEST_2_each_test_block_has_its_own_output
 
 =head2 Valgrind Integration
 

--- a/t/0-archive.t
+++ b/t/0-archive.t
@@ -10,6 +10,7 @@ use Test::Nginx::Socket;
 use File::Path 'remove_tree';
 use File::Spec::Functions 'catfile';
 
+plan skip_all => "nginx is required but not found" if system('nginx -h >/dev/null 2>&1') != 0;
 repeat_each(2);
 plan tests => 8 * blocks();
 
@@ -28,7 +29,7 @@ __DATA__
 
 --- response_body eval
 ["", ""]
-=== TEST 2: each test block has its own output
+=== TEST 1: create files to be archived
 --- config
     location /t {
         return 200;

--- a/t/0-archive.t
+++ b/t/0-archive.t
@@ -1,0 +1,34 @@
+# Unit test for TEST_NGINX_ARCHIVE_PATH
+use Test::Nginx::Socket;
+use File::Path 'remove_tree';
+use File::Spec::Functions 'catfile';
+use Cwd qw(cwd);
+
+repeat_each(2);
+plan tests => 8 * blocks();
+
+remove_tree($ENV{TEST_NGINX_ARCHIVE_PATH});
+run_tests();
+
+__DATA__
+
+=== TEST 1: create files to be archived
+--- config
+    location /t {
+        return 200;
+    }
+--- pipelined_requests eval
+["GET /t", "GET /t"]
+
+--- response_body eval
+["", ""]
+=== TEST 2: each test block has its own output
+--- config
+    location /t {
+        return 200;
+    }
+--- pipelined_requests eval
+["GET /t", "GET /t"]
+
+--- response_body eval
+["", ""]

--- a/t/0-archive.t
+++ b/t/0-archive.t
@@ -1,8 +1,14 @@
 # Unit test for TEST_NGINX_ARCHIVE_PATH
+use Cwd qw(cwd);
+BEGIN {
+    my $pwd = cwd();
+    $ENV{TEST_NGINX_ARCHIVE_PATH} = 't/servroot';
+    $ENV{TEST_NGINX_SERVROOT} = "$pwd/t/archive";
+}
+
 use Test::Nginx::Socket;
 use File::Path 'remove_tree';
 use File::Spec::Functions 'catfile';
-use Cwd qw(cwd);
 
 repeat_each(2);
 plan tests => 8 * blocks();

--- a/t/archive.t
+++ b/t/archive.t
@@ -1,0 +1,27 @@
+# Unit test for TEST_NGINX_ARCHIVE_PATH, requires 0-archive.t runs ahead
+use Test::Nginx::Socket;
+use File::Spec::Functions 'catfile';
+
+plan tests => 5;
+
+my $archive = catfile($ENV{TEST_NGINX_ARCHIVE_PATH},
+    't.0-archive.TEST_1:_create_files_to_be_archived');
+ok(-f catfile($archive, 'logs', 'error.log'), 'Archive error.log');
+ok(-f catfile($archive, 'logs', 'access.log'), 'Archive access.log');
+ok(-f catfile($archive, 'conf', 'nginx.conf'), 'Archive nginx.conf');
+
+sub count_occurrence_in_file($$) {
+    my ($filename, $pattern) = @_;
+    # Fail directly if output file is missing.
+    open my $fh, '<', $filename or die "error opening $filename: $!";
+    my $text = do { local $/; <$fh> };
+    my $count = () = $text =~ /$pattern/g;
+    return $count;
+}
+
+my $filename = catfile($archive, 'output');
+is(count_occurrence_in_file($filename, "200 OK"), 4, "Archive output for TEST 1");
+$archive = catfile($ENV{TEST_NGINX_ARCHIVE_PATH},
+    't.0-archive.TEST_2:_each_test_block_has_its_own_output');
+$filename = catfile($archive, 'output');
+is(count_occurrence_in_file($filename, "200 OK"), 4, "Archive output for TEST 2");

--- a/t/archive.t
+++ b/t/archive.t
@@ -2,13 +2,15 @@
 BEGIN {
     $ENV{TEST_NGINX_ARCHIVE_PATH} = 't/servroot';
 }
-use Test::Nginx::Socket;
+
+use Test::More;
 use File::Spec::Functions 'catfile';
 
+plan skip_all => "nginx is required but not found" if system('nginx -h >/dev/null 2>&1') != 0;
 plan tests => 5;
 
 my $archive = catfile($ENV{TEST_NGINX_ARCHIVE_PATH},
-    't.0-archive.TEST_1:_create_files_to_be_archived');
+    't.0-archive.TEST_1_create_files_to_be_archived');
 ok(-f catfile($archive, 'logs', 'error.log'), 'Archive error.log');
 ok(-f catfile($archive, 'logs', 'access.log'), 'Archive access.log');
 ok(-f catfile($archive, 'conf', 'nginx.conf'), 'Archive nginx.conf');
@@ -23,8 +25,8 @@ sub count_occurrence_in_file($$) {
 }
 
 my $filename = catfile($archive, 'output');
-is(count_occurrence_in_file($filename, "200 OK"), 4, "Archive output for TEST 1");
+is(count_occurrence_in_file($filename, "200 OK"), 4, "Archive output");
 $archive = catfile($ENV{TEST_NGINX_ARCHIVE_PATH},
-    't.0-archive.TEST_2:_each_test_block_has_its_own_output');
+    't.0-archive.TEST_1_create_files_to_be_archived.1');
 $filename = catfile($archive, 'output');
-is(count_occurrence_in_file($filename, "200 OK"), 4, "Archive output for TEST 2");
+is(count_occurrence_in_file($filename, "200 OK"), 4, "Archive output for test with same name");

--- a/t/archive.t
+++ b/t/archive.t
@@ -1,4 +1,7 @@
 # Unit test for TEST_NGINX_ARCHIVE_PATH, requires 0-archive.t runs ahead
+BEGIN {
+    $ENV{TEST_NGINX_ARCHIVE_PATH} = 't/servroot';
+}
 use Test::Nginx::Socket;
 use File::Spec::Functions 'catfile';
 


### PR DESCRIPTION
For #42 
1. Only archive files and output of tests which setup a nginx server and run to complete.
2. Merge output from each run to a single output file.