### PR TITLE
Allow for perl subs in tcp_reply eval filters

### DIFF
--- a/lib/Test/Nginx/Socket.pm
+++ b/lib/Test/Nginx/Socket.pm
@@ -3602,7 +3602,24 @@ Just like C<udp_reply_delay>, but for the embedded TCP server.
 
 =head2 tcp_reply
 
-Just like C<tcp_reply>, but for the embedded TCP server.
+Just like C<udp_reply>, but for the embedded TCP server.
+
+Like the C<udp_reply> section, this section also accepts a Perl subroutine value
+that can be used to generate dynamic response packet or packets based on the actual query, for example:
+
+    --- tcp_reply eval
+    sub {
+        my $req = shift;
+        return "hello, $req";
+    }
+
+The custom Perl subroutine can also return an array reference, for example,
+
+    --- tcp_reply eval
+    sub {
+        my $req = shift;
+        return ["hello, $req", "hiya, $req"];
+    }
 
 =head2 tcp_query
 

--- a/lib/Test/Nginx/Util.pm
+++ b/lib/Test/Nginx/Util.pm
@@ -1945,12 +1945,12 @@ request:
                     }
                 }
 
+                my $buf;
+
                 unless ($no_read) {
                     if ($Verbose) {
                         warn "TCP server reading request...\n";
                     }
-
-                    my $buf;
 
                     while (1) {
                         my $b;
@@ -2003,7 +2003,17 @@ request:
                             warn "TCP server writing reply...\n";
                         }
 
+                        my $ref = ref $reply;
+                        if ($ref && $ref eq 'CODE') {
+                            $reply = $reply->($buf);
+                            $ref = ref $reply;
+                        }
+
                         if (ref $reply) {
+                            if ($ref ne 'ARRAY') {
+                                bail_out('bad --- tcp_reply value');
+                            }
+
                             for my $r (@$reply) {
                                 if ($Verbose) {
                                     warn "sending reply $r";


### PR DESCRIPTION
It's in udp_reply, and it's not documented that it's not (currently)
in tcp_reply.