### PR TITLE
Feature/support shutdown_error_log

### DIFF
--- a/lib/Test/Nginx/Socket.pm
+++ b/lib/Test/Nginx/Socket.pm
@@ -2398,11 +2398,11 @@ Default to 1.
 
 =head2 stop_after_request
 
-By default, the nginx is not still running after the request. The error log is incompletely, missing logs after nginx shutdown.
+By default, the nginx is not still running after the request. The error log is incompletely, missing logs after nginx stoped.
 
 You can set this flag to ensure that you can get fully nginx error log.
 
-Because of the nginx is shutdowned, the C<repeat_each> number must be set to 1.
+Because of the nginx is stoped, the C<repeat_each> number must be set to 1.
 
 =head2 env_to_nginx
 

--- a/lib/Test/Nginx/Socket.pm
+++ b/lib/Test/Nginx/Socket.pm
@@ -2396,6 +2396,14 @@ to run the specified number of duplicate requests for each test block. When it i
 
 Default to 1.
 
+=head2 stop_after_request
+
+By default, the nginx is not still running after the request. The error log is incompletely, missing logs after nginx shutdown.
+
+You can set this flag to ensure that you can get fully nginx error log.
+
+Because of the nginx is shutdowned, the C<repeat_each> number must be set to 1.
+
 =head2 env_to_nginx
 
 Specify additional system environmnt variables to be passed into the nginx server.

--- a/lib/Test/Nginx/Socket.pm
+++ b/lib/Test/Nginx/Socket.pm
@@ -815,16 +815,17 @@ again:
             sleep $TestNginxSleep;
         }
 
-        my $max_i = 15;
-        for (my $i = 1; $i <= $max_i; $i++) {
+        my $max_tries = 15;
+        for (my $i = 1; $i <= $max_tries; $i++) {
             last unless is_running($ngx_pid);
 
             sleep $TestNginxSleep;
-            next if $i < $max_i;
+            next if $i < $max_tries;
 
             warn "WARNING: killing nginx $ngx_pid with force...";
             kill(SIGKILL, $ngx_pid);
             waitpid($ngx_pid, 0);
+            sleep $TestNginxSleep;
         }
     }
 
@@ -2398,11 +2399,12 @@ Default to 1.
 
 =head2 stop_after_request
 
-By default, the nginx is not still running after the request. The error log is incompletely, missing logs after nginx stoped.
+By default, after the first request, nginx is still running until the next test case or end.
+Therefore, the error log is missing from the part generated during nginx exit.
 
-You can set this flag to ensure that you can get fully nginx error log.
+To get complete nginx error log, You can set this flag to stop nginx after the first request.
 
-Because of the nginx is stoped, the C<repeat_each> number must be set to 1.
+Because the nginx will be stopped, the C<repeat_each> number can not be set to other but 1(default).
 
 =head2 env_to_nginx
 
@@ -3341,7 +3343,7 @@ Below is an example from ngx_headers_more module's test suite:
     --- response_headers
     ! X-Foo
     --- response_body
-    x-foo:
+    x-foo: 
     --- http09
 
 =head2 ignore_response
@@ -4231,3 +4233,4 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 =head1 SEE ALSO
 
 L<Test::Nginx::Lua>, L<Test::Nginx::Lua::Stream>, L<Test::Nginx::LWP>, L<Test::Base>.
+

--- a/lib/Test/Nginx/Util.pm
+++ b/lib/Test/Nginx/Util.pm
@@ -1205,6 +1205,11 @@ sub run_test ($) {
         }
     }
 
+    if (defined $block->stop_after_request && $RepeatEach != 1){
+       bail_out("the directive \"stop_after_request\" runs once per case. the \"repeat_each\" number should be 1.");
+       die;
+   }
+
     if (!defined $config) {
         if (!$NoNginxManager) {
             # Manager without config.

--- a/lib/Test/Nginx/Util.pm
+++ b/lib/Test/Nginx/Util.pm
@@ -1206,7 +1206,7 @@ sub run_test ($) {
     }
 
     if (defined $block->stop_after_request && $RepeatEach != 1){
-       bail_out("\"stop_after_request\" flag is enable, nginx will be stoped after request. \"repeat_each\" number must be set to 1.");
+       bail_out("\"stop_after_request\" flag is enabled, nginx will be stopped after first request. \"repeat_each\" number must be set to 1(default).");
        die;
    }
 

--- a/lib/Test/Nginx/Util.pm
+++ b/lib/Test/Nginx/Util.pm
@@ -1206,7 +1206,7 @@ sub run_test ($) {
     }
 
     if (defined $block->stop_after_request && $RepeatEach != 1){
-       bail_out("\"stop_after_request\" flag is enabled, nginx will be stopped after first request. \"repeat_each\" number must be set to 1(default).");
+       bail_out("\"stop_after_request\" flag is enabled, nginx will be stopped after the first request. \"repeat_each\" number must be set to 1(default).");
        die;
    }
 

--- a/lib/Test/Nginx/Util.pm
+++ b/lib/Test/Nginx/Util.pm
@@ -1206,7 +1206,7 @@ sub run_test ($) {
     }
 
     if (defined $block->stop_after_request && $RepeatEach != 1){
-       bail_out("the directive \"stop_after_request\" runs once per case. the \"repeat_each\" number should be 1.");
+       bail_out("\"stop_after_request\" flag is enable, nginx will be stoped after request. \"repeat_each\" number must be set to 1.");
        die;
    }
 


### PR DESCRIPTION
By default, the nginx is not still running after the request. The error log is incompletely, missing logs after nginx stoped.

You can set this flag to ensure that you can get fully nginx error log.

Because of the nginx is stoped, the C<repeat_each> number must be set to 1.

here is an example:

```
=== TEST 1: 
--- http_config
--- config
    location /t {
        echo "ok";
    }
--- request
GET /t
--- stop_after_request
--- error_log
received, shutting down
```