### PR TITLE
feature: add check for random port, if it's used by other local services.

### DIFF
--- a/lib/Test/Nginx/Socket.pm
+++ b/lib/Test/Nginx/Socket.pm
@@ -3992,6 +3992,17 @@ only see the logs for the last test run (which you usually do not control
 except if you set C<TEST_NGINX_NO_SHUFFLE=1>). With this, you accumulate
 all logs into a single file that is never cleaned up by Test::Nginx.
 
+=head2 TEST_NGINX_RANDOMIZE
+
+When set, the test scaffold forces the use of random server listening port numbers as
+well as random C<t/servroot_XXXX/> directories. This can help test suite run in multiple
+parallel jobs via C<prove -jN> where C<N> is an integer bigger than 1. For instance,
+C<prove -j8 -r t> runs the test suite under F<t/> in 8 parallel jobs, utilizing up to
+8 (logical) CPU cores in the same machine.
+
+Note that only test suite I<without> external shared service dependencies (like Memcached,
+Redis or MySQL) can run in parallel in this way, obviously.
+
 =head2 Valgrind Integration
 
 Test::Nginx has integrated support for valgrind (L<http://valgrind.org>) even though by

--- a/lib/Test/Nginx/Socket.pm
+++ b/lib/Test/Nginx/Socket.pm
@@ -4000,7 +4000,7 @@ parallel jobs via C<prove -jN> where C<N> is an integer bigger than 1. For insta
 C<prove -j8 -r t> runs the test suite under F<t/> in 8 parallel jobs, utilizing up to
 8 (logical) CPU cores in the same machine.
 
-Note that only test suite I<without> external shared service dependencies (like Memcached,
+Note that only test suite I<without> external shared and writable service dependencies (like Memcached,
 Redis or MySQL) can run in parallel in this way, obviously.
 
 =head2 Valgrind Integration

--- a/lib/Test/Nginx/Util.pm
+++ b/lib/Test/Nginx/Util.pm
@@ -243,7 +243,30 @@ our $ForceRestartOnTest     = (defined $ENV{TEST_NGINX_FORCE_RESTART_ON_TEST})
 
 if ($Randomize) {
     srand $$;
-    $ServerPort = int(rand 60000) + 1025;
+
+    for (my $i = 0; $i <= 1000; $i++) {
+        $ServerPort = int(rand 60000) + 1025;
+
+        my $sock = IO::Socket::INET->new(
+            PeerAddr => $ServerAddr,
+            PeerPort => $ServerPort,
+            Proto => 'tcp',
+            Timeout => 0.1,
+        );
+
+        last if !defined $sock;
+
+        $sock->close();
+
+        if ($i == 1000) {
+            bail_out "Cannot find port not in use after $i tries!\n";
+        }
+
+        if ($Verbose) {
+            warn "try again, port $ServerPort is in use!";
+        }
+    }
+
     $ServerPortForClient = $ServerPort;
 }
 

--- a/lib/Test/Nginx/Util.pm
+++ b/lib/Test/Nginx/Util.pm
@@ -554,10 +554,8 @@ sub kill_process ($$) {
 }
 
 sub cleanup () {
-    if ($Randomize) {
-        if (-d $ServRoot && $ServRoot =~ m{/t/servroot_\d+}) {
-            system("rm -rf $ServRoot");
-        }
+    if ($Verbose) {
+        warn "cleaning up everyitng";
     }
 
     for my $hdl (@CleanupHandlers) {
@@ -2403,6 +2401,12 @@ END {
             } else {
                 unlink $PidFile;
             }
+        }
+    }
+
+    if ($Randomize) {
+        if (-d $ServRoot && $ServRoot =~ m{/t/servroot_\d+}) {
+            system("rm -rf $ServRoot");
         }
     }
 }

--- a/lib/Test/Nginx/Util.pm
+++ b/lib/Test/Nginx/Util.pm
@@ -442,7 +442,7 @@ sub add_block_preprocessor(&) {
 #our ($PrevRequest)
 our $PrevConfig;
 
-our $ServRoot   = $ENV{TEST_NGINX_SERVROOT} || File::Spec->rel2abs('t/servroot');
+our $ServRoot = $ENV{TEST_NGINX_SERVROOT} || File::Spec->rel2abs('t/servroot');
 
 if ($Randomize) {
     $ServRoot = File::Spec->rel2abs("t/servroot_" . $ServerPort);

--- a/lib/Test/Nginx/Util.pm
+++ b/lib/Test/Nginx/Util.pm
@@ -226,6 +226,7 @@ our @BlockPreprocessors;
 
 sub bail_out (@);
 
+our $Randomize              = $ENV{TEST_NGINX_RANDOMIZE};
 our $NginxBinary            = $ENV{TEST_NGINX_BINARY} || 'nginx';
 our $Workers                = 1;
 our $WorkerConnections      = 64;
@@ -233,12 +234,18 @@ our $LogLevel               = $ENV{TEST_NGINX_LOG_LEVEL} || 'debug';
 our $MasterProcessEnabled   = $ENV{TEST_NGINX_MASTER_PROCESS} || 'off';
 our $DaemonEnabled          = 'on';
 our $ServerPort             = $ENV{TEST_NGINX_SERVER_PORT} || $ENV{TEST_NGINX_PORT} || 1984;
-our $ServerPortForClient    = $ENV{TEST_NGINX_CLIENT_PORT} || $ENV{TEST_NGINX_PORT} || 1984;
+our $ServerPortForClient    = $ENV{TEST_NGINX_CLIENT_PORT} || $ServerPort || 1984;
 our $NoRootLocation         = 0;
 our $TestNginxSleep         = $ENV{TEST_NGINX_SLEEP} || 0.015;
 our $BuildSlaveName         = $ENV{TEST_NGINX_BUILDSLAVE};
 our $ForceRestartOnTest     = (defined $ENV{TEST_NGINX_FORCE_RESTART_ON_TEST})
                                ? $ENV{TEST_NGINX_FORCE_RESTART_ON_TEST} : 1;
+
+if ($Randomize) {
+    srand $$;
+    $ServerPort = int(rand 60000) + 1025;
+    $ServerPortForClient = $ServerPort;
+}
 
 our $ChildPid;
 our $UdpServerPid;
@@ -435,7 +442,12 @@ sub add_block_preprocessor(&) {
 #our ($PrevRequest)
 our $PrevConfig;
 
-our $ServRoot   = $ENV{TEST_NGINX_SERVROOT} || File::Spec->catfile(cwd() || '.', 't/servroot');
+our $ServRoot   = $ENV{TEST_NGINX_SERVROOT} || File::Spec->rel2abs('t/servroot');
+
+if ($Randomize) {
+    $ServRoot = File::Spec->rel2abs("t/servroot_" . $ServerPort);
+}
+
 our $LogDir     = File::Spec->catfile($ServRoot, 'logs');
 our $ErrLogFile = File::Spec->catfile($LogDir, 'error.log');
 our $AccLogFile = File::Spec->catfile($LogDir, 'access.log');
@@ -542,6 +554,12 @@ sub kill_process ($$) {
 }
 
 sub cleanup () {
+    if ($Randomize) {
+        if (-d $ServRoot && $ServRoot =~ m{/t/servroot_\d+}) {
+            system("rm -rf $ServRoot");
+        }
+    }
+
     for my $hdl (@CleanupHandlers) {
        $hdl->();
     }


### PR DESCRIPTION
1. kill nginx in clean_up when TEST_NGINX_RANDOMIZE is enable
2. add some port conflict check