### PR TITLE
bugfix: re-enable usage of TEST_NGINX_BINARY

### DIFF
--- a/lib/Test/Nginx/Util.pm
+++ b/lib/Test/Nginx/Util.pm
@@ -2398,17 +2398,23 @@ END {
 sub can_run {
     my ($cmd) = @_;
 
-    #warn "can run: @_\n";
-    #my $_cmd = $cmd;
-    #return $_cmd if (-x $_cmd or $_cmd = MM->maybe_command($_cmd));
+    #warn "can run: $cmd\n";
+    if ($cmd =~ /[\/\\]/) {
+       if (-f $cmd && -x $cmd) {
+           return $cmd;
+        }
+
+        return undef;
+    }
 
     for my $dir ((split /$Config::Config{path_sep}/, $ENV{PATH}), '.') {
         next if $dir eq '';
-        my $abs = File::Spec->catfile($dir, $_[0]);
+        my $abs = File::Spec->catfile($dir, $cmd);
+        #warn $abs;
         return $abs if -f $abs && -x $abs;
     }
 
-    return;
+    return undef;
 }
 
 1;


### PR DESCRIPTION
Prior to this patch, specifying $TEST_NGINX_BINARY has the
effect of iterating over $PATH segments, and concatenating the specified
path. Ex:

    $ TEST_NGINX_BINARY=/some/path/nginx prove t/
        testing: /usr/loca/bin//some/path/nginx
        testing: /usr/bin//some/path/nginx
        etc...

Hence this variable only has effect if it specifies a command name
available in the $PATH, which is contrary to that part of the
documentation, if I interpret it correctly:

> Can be used as an alternative to setting PATH to run a specific
> nginx instance.

This behavior I believe was broken by
eea73704b195292a6acad8a75f4b069a02fa86c0.

With this patch, we ensure the given $cmd is an executable file:

    $ TEST_NGINX_BINARY=/some/path/nginx prove t/
        testing: /some/path/nginx