### PR TITLE
feature: added --- skip_check_config_version to skip check config_version after HUP reload.

### DIFF
--- a/lib/Test/Nginx/Socket.pm
+++ b/lib/Test/Nginx/Socket.pm
@@ -3316,6 +3316,10 @@ Below is an example from ngx_headers_more module's test suite:
 
 Do not attempt to parse the response or run the response related subtests.
 
+=head2 reload_fails
+
+Allow HUP reload fails, that means the server still use the previous config.
+
 =head2 user_files
 
 With this section you can create a file that will be copied in the

--- a/lib/Test/Nginx/Util.pm
+++ b/lib/Test/Nginx/Util.pm
@@ -1517,7 +1517,7 @@ sub run_test ($) {
                                 warn "$name\n";
                             }
 
-                            if (defined $block->skip_check_config_version) {
+                            if (defined $block->reload_fails) {
                                 sleep 0.1;
 
                             } else {

--- a/lib/Test/Nginx/Util.pm
+++ b/lib/Test/Nginx/Util.pm
@@ -1517,7 +1517,12 @@ sub run_test ($) {
                                 warn "$name\n";
                             }
 
-                            test_config_version($name);
+                            if (defined $block->skip_check_config_version) {
+                                sleep 0.1;
+
+                            } else {
+                                test_config_version($name);
+                            }
 
                             goto request;
 


### PR DESCRIPTION
Yeah, a little hacky here, because we need this to test the following cases:
https://github.com/openresty/lua-nginx-module/pull/1002