### PR TITLE
Bail out for benchmark run failures

### DIFF
--- a/lib/Test/Nginx/Socket.pm
+++ b/lib/Test/Nginx/Socket.pm
@@ -611,7 +611,11 @@ sub run_test_helper ($$) {
         $cmd = quote_sh_args($cmd);
 
         warn "$cmd\n";
-        system "unbuffer $cmd > /dev/stderr";
+        my $full_cmd = "unbuffer $cmd > /dev/stderr";
+        my $rc = system $full_cmd;
+        if ($rc != 0) {
+          bail_out("Failure running '${full_cmd}': return code ${rc}");
+        }
     }
 
     if ($CheckLeak && !defined $block->no_check_leak) {

--- a/lib/Test/Nginx/Socket.pm
+++ b/lib/Test/Nginx/Socket.pm
@@ -611,10 +611,9 @@ sub run_test_helper ($$) {
         $cmd = quote_sh_args($cmd);
 
         warn "$cmd\n";
-        my $full_cmd = "unbuffer $cmd > /dev/stderr";
-        my $rc = system $full_cmd;
-        if ($rc != 0) {
-          bail_out("Failure running '${full_cmd}': return code ${rc}");
+        $cmd = "unbuffer $cmd > /dev/stderr";
+        if (system($cmd) != 0) {
+          bail_out("Failed to run '${cmd}': return code $?");
         }
     }
 


### PR DESCRIPTION
Exit with non-zero return code during benchmark failures.