### PR TITLE
feature: add exported perl functions `add_global_init_processor`

### DIFF
--- a/lib/Test/Nginx/Socket.pm
+++ b/lib/Test/Nginx/Socket.pm
@@ -38,7 +38,7 @@ our @EXPORT = qw( env_to_nginx is_str plan run_tests run_test
   server_name
   server_addr server_root html_dir server_port server_port_for_client
   timeout no_nginx_manager check_accum_error_log
-  add_block_preprocessor bail_out add_cleanup_handler
+  add_block_preprocessor add_global_init_processor bail_out add_cleanup_handler
   add_response_body_check
 );
 

--- a/lib/Test/Nginx/Util.pm
+++ b/lib/Test/Nginx/Util.pm
@@ -237,6 +237,7 @@ sub no_nginx_manager () {
 
 our @CleanupHandlers;
 our @BlockPreprocessors;
+our @GlobalInitProcessors;
 
 sub bail_out (@);
 
@@ -444,6 +445,7 @@ our @EXPORT = qw(
     $Benchmark
     $BenchmarkWarmup
     add_block_preprocessor
+    add_global_init_processor
     timeout
     worker_connections
     workers
@@ -485,6 +487,10 @@ our $NginxRawVersion;
 
 sub add_block_preprocessor(&) {
     unshift @BlockPreprocessors, shift;
+}
+
+sub add_global_init_processor(&) {
+    unshift @GlobalInitProcessors, shift;
 }
 
 #our ($PrevRequest)
@@ -706,6 +712,10 @@ sub run_tests () {
 
     if (!defined $ENV{TEST_NGINX_SERVER_PORT}) {
         $ENV{TEST_NGINX_SERVER_PORT} = $ServerPort;
+    }
+
+    for my $gi (@GlobalInitProcessors) {
+        $gi->();
     }
 
     for my $block ($NoShuffle ? Test::Base::blocks() : shuffle Test::Base::blocks()) {


### PR DESCRIPTION
Hello:
  we can use this func to do something like `init some data into mysql' before test blocks
Signed-off-by: hongliang <513918845@qq.com>