### PR TITLE
bugfix: remove duplicate `cleanup` function call

### DIFF
--- a/lib/Test/Nginx/Util.pm
+++ b/lib/Test/Nginx/Util.pm
@@ -2473,8 +2473,6 @@ retry:
 END {
     return if $InSubprocess;
 
-    cleanup();
-
     if ($UseStap || $UseValgrind || !$ENV{TEST_NGINX_NO_CLEAN}) {
         local $?; # to avoid confusing Test::Builder::_ending
         if (defined $PidFile && -f $PidFile) {


### PR DESCRIPTION
Hello:
  `run_tests` function  alaways call `cleanup()`   https://github.com/openresty/test-nginx/blob/master/lib/Test/Nginx/Util.pm#L721
But `END` call `cleanup()` twice https://github.com/openresty/test-nginx/blob/master/lib/Test/Nginx/Util.pm#L2476. 
Signed-off-by: hongliang <513918845@qq.com>