### PR TITLE
bugfix: ensured we do not remove some files when using HUP mode.

### DIFF
--- a/lib/Test/Nginx/Util.pm
+++ b/lib/Test/Nginx/Util.pm
@@ -733,13 +733,13 @@ sub setup_server_root () {
     if (-d $ServRoot) {
         # Take special care, so we won't accidentally remove
         # real user data when TEST_NGINX_SERVROOT is mis-used.
-        remove_tree($ConfDir, $HtmlDir, glob("$ServRoot/*_cache"),
+        remove_tree($ConfDir, glob("$ServRoot/*_cache"),
                     glob("$ServRoot/*_temp"));
 
         if ($UseHup) {
             find({ bydepth => 1, no_chdir => 1, wanted => sub {
                 if (! -d $_) {
-                    if ($_ =~ /\bnginx\.pid$/) {
+                    if ($_ =~ /(?:\bnginx\.pid|\.sock|\.crt|\.key)$/) {
                         return;
                     }
 
@@ -750,7 +750,7 @@ sub setup_server_root () {
             }}, $ServRoot);
 
         } else {
-            remove_tree($LogDir);
+            remove_tree($HtmlDir, $LogDir);
             rmdir $ServRoot or
                 bail_out "Can't remove $ServRoot (not empty?): $!";
         }
@@ -763,8 +763,10 @@ sub setup_server_root () {
         mkdir $LogDir or
             bail_out "Failed to do mkdir $LogDir\n";
     }
-    mkdir $HtmlDir or
-        bail_out "Failed to do mkdir $HtmlDir\n";
+    if (!-d $HtmlDir) {
+        mkdir $HtmlDir or
+            bail_out "Failed to do mkdir $HtmlDir\n";
+    }
 
     my $index_file = "$HtmlDir/index.html";
 


### PR DESCRIPTION
Due to eda1139, the html prefix directory is removed in between tests
when using the HUP mode. However, in this directory many test suites
write a unix socket file, or TLS certificates and keys.

This patch avoids that these files be removed, which would cause
failures such as:

    t/129-ssl-socket.t .. 121/422
    Failed test 'TEST 21: unix domain ssl cosocket (verify) - response_body - response is expected (repeated req 0, req 0)'
    at /home/chasum/code/openresty/dev/test-nginx/lib/Test/Nginx/Socket.pm line 1589.
    @@ -1,11 +1 @@
    -connected: 1
    +failed to connect: no such file or directory
    -ssl handshake: userdata
    -sent http request: 56 bytes.
    -received: HTTP/1.1 201 Created
    -received: Server: nginx
    -received: Content-Type: text/plain
    -received: Content-Length: 4
    -received: Connection: close
    -received:
    -received: foo
    -close: 1 nil

    Failed test 'TEST 21: unix domain ssl cosocket (verify) - grep_error_log_out (req 0)'
    at /home/chasum/code/openresty/dev/test-nginx/lib/Test/Nginx/Socket.pm line 1146.
                   ''
    doesn't match '(?^:^lua ssl save session: ([0-9A-F]+)
    lua ssl free session: ([0-9A-F]+)
    $)'