### PR TITLE
bugfix: ensure servroot is cleaned up when starting NGINX for the first time.

### DIFF
--- a/lib/Test/Nginx/Util.pm
+++ b/lib/Test/Nginx/Util.pm
@@ -729,7 +729,9 @@ sub run_tests () {
     cleanup();
 }
 
-sub setup_server_root () {
+sub setup_server_root ($) {
+    my $first_time = shift;
+
     if (-d $ServRoot) {
         # Take special care, so we won't accidentally remove
         # real user data when TEST_NGINX_SERVROOT is mis-used.
@@ -740,7 +742,7 @@ sub setup_server_root () {
             find({ bydepth => 1, no_chdir => 1, wanted => sub {
                 if (! -d $_) {
                     if ($_ =~ /(?:\bnginx\.pid|\.sock|\.crt|\.key)$/) {
-                        return;
+                        return unless $first_time;
                     }
 
                     #warn "removing file $_";
@@ -1631,7 +1633,7 @@ sub run_test ($) {
                         goto start_nginx;
                     }
 
-                    setup_server_root();
+                    setup_server_root($first_time);
                     write_user_files($block);
                     write_config_file($block, $config);
 
@@ -1709,7 +1711,7 @@ start_nginx:
             #system("killall -9 nginx");
 
             #warn "*** Restarting the nginx server...\n";
-            setup_server_root();
+            setup_server_root($first_time);
             write_user_files($block);
             write_config_file($block, $config);
             #warn "nginx binary: $NginxBinary";

--- a/lib/Test/Nginx/Util.pm
+++ b/lib/Test/Nginx/Util.pm
@@ -1200,7 +1200,7 @@ sub test_config_version ($$) {
     $tb->no_ending(1);
 
     Test::More::fail("$name - failed to reload configuration after $total "
-                     .. "failed test requests");
+                     . "failed test requests");
 }
 
 sub parse_headers ($) {


### PR DESCRIPTION
Since 56733f3, we do not remove all files in the servroot/html
directory, which is necessary for existing test cases when running in
HUP mode.

However, an existing issue with NGINX (trac #753
https://trac.nginx.org/nginx/ticket/753) causes the SIGQUIT signal
(graceful exit) to not remove listening unix socket files. This causes
subsequent tests run to fail due to NGINX to being able to bind since
the file already exists.

This fix ensures that we remove all files in the servroot/html
directory before running a test suite.