### PR TITLE
bugfix: TEST_NGINX_RAND_PORT_XXX should work only in one test block.

### DIFF
--- a/lib/Test/Nginx/Util.pm
+++ b/lib/Test/Nginx/Util.pm
@@ -797,7 +797,7 @@ sub setup_server_root ($) {
 }
 
 sub write_user_files ($$) {
-    my ($block, $rand_ports) = shift;
+    my ($block, $rand_ports) = @_;
 
     my $name = $block->name;
 

--- a/lib/Test/Nginx/Util.pm
+++ b/lib/Test/Nginx/Util.pm
@@ -1251,7 +1251,8 @@ sub expand_env_in_text ($$$) {
     };
 
     $text =~ s/\$(TEST_NGINX_[_A-Z0-9]+)/
-        my $repl;
+        my $expanded_env;
+
         if ($1 =~ m{^(TEST_NGINX_RAND_PORT_[0-9]+)$}) {
             if (!defined $rand_ports->{$1}) {
                 my $rand_port = gen_rand_port 1000, $used_ports;
@@ -1262,18 +1263,19 @@ sub expand_env_in_text ($$$) {
 
                 $rand_ports->{$1} = $rand_port;
                 $used_ports->{$rand_port} = 1;
-                $repl = $rand_port;
+                $expanded_env = $rand_port;
 
             } else {
-                $repl = $rand_ports->{$1};
+                $expanded_env = $rand_ports->{$1};
             }
         } else {
             if (!defined $ENV{$1}) {
                 bail_out "$name - No environment $1 defined.\n";
             }
-            $repl = $ENV{$1};
+            $expanded_env = $ENV{$1};
         }
-        $repl/eg;
+        $expanded_env;
+    /eg;
 
     $text;
 }

--- a/lib/Test/Nginx/Util.pm
+++ b/lib/Test/Nginx/Util.pm
@@ -796,8 +796,8 @@ sub setup_server_root ($) {
         bail_out "Failed to do mkdir $ConfDir\n";
 }
 
-sub write_user_files ($) {
-    my $block = shift;
+sub write_user_files ($$) {
+    my ($block, $rand_ports) = shift;
 
     my $name = $block->name;
 
@@ -856,7 +856,7 @@ sub write_user_files ($) {
                 }
             }
 
-            $body = expand_env_in_text($body, $name);
+            $body = expand_env_in_text($body, $name, $rand_ports);
 
             open my $out, ">$path" or
                 bail_out "$name - Cannot open $path for writing: $!\n";
@@ -874,8 +874,8 @@ sub write_user_files ($) {
     }
 }
 
-sub write_config_file ($$) {
-    my ($block, $config) = @_;
+sub write_config_file ($$$) {
+    my ($block, $config, $rand_ports) = @_;
 
     my $name = $block->name;
     my $http_config = $block->http_config;
@@ -894,7 +894,7 @@ sub write_config_file ($$) {
         master_off();
     }
 
-    $http_config = expand_env_in_text($http_config, $name);
+    $http_config = expand_env_in_text($http_config, $name, $rand_ports);
 
     if (!defined $config) {
         $config = '';
@@ -932,13 +932,13 @@ sub write_config_file ($$) {
         }
     }
 
-    $main_config = expand_env_in_text($main_config, $name);
+    $main_config = expand_env_in_text($main_config, $name, $rand_ports);
 
     if (!defined $post_main_config) {
         $post_main_config = '';
     }
 
-    $post_main_config = expand_env_in_text($post_main_config, $name);
+    $post_main_config = expand_env_in_text($post_main_config, $name, $rand_ports);
 
     if ($CheckLeak || $Benchmark) {
         $LogLevel = 'warn';
@@ -1238,32 +1238,42 @@ sub parse_headers ($) {
     return \%headers;
 }
 
-sub expand_env_in_text ($$) {
-    my ($text, $name) = @_;
+sub expand_env_in_text ($$$) {
+    my ($text, $name, $rand_ports) = @_;
 
     if (!defined $text) {
         return;
     }
 
-    my $used_ports = { $ServerPort => 1 };
+    my $used_ports = {
+        $ServerPort => 1,
+        map { $_ => 1 } values %$rand_ports
+    };
 
     $text =~ s/\$(TEST_NGINX_[_A-Z0-9]+)/
+        my $repl;
         if ($1 =~ m{^(TEST_NGINX_RAND_PORT_[0-9]+)$}) {
-            if (!defined $ENV{$1}) {
+            if (!defined $rand_ports->{$1}) {
                 my $rand_port = gen_rand_port 1000, $used_ports;
 
                 if (!defined $rand_port) {
                     bail_out "$name - Cannot find an available listening port number for $1.\n";
                 }
 
-                $ENV{$1} = $rand_port;
+                $rand_ports->{$1} = $rand_port;
                 $used_ports->{$rand_port} = 1;
-            }
+                $repl = $rand_port;
 
-        } elsif (!defined $ENV{$1}) {
-            bail_out "$name - No environment $1 defined.\n";
+            } else {
+                $repl = $rand_ports->{$1};
+            }
+        } else {
+            if (!defined $ENV{$1}) {
+                bail_out "$name - No environment $1 defined.\n";
+            }
+            $repl = $ENV{$1};
         }
-        $ENV{$1}/eg;
+        $repl/eg;
 
     $text;
 }
@@ -1347,9 +1357,11 @@ sub run_test ($) {
         undef $FirstTime;
     }
 
+    my $rand_ports = {};
+
     my $config = $block->config;
 
-    $config = expand_env_in_text($config, $name);
+    $config = expand_env_in_text($config, $name, $rand_ports);
 
     my $dry_run = 0;
     my $should_restart = 1;
@@ -1662,8 +1674,8 @@ sub run_test ($) {
                     }
 
                     setup_server_root($first_time);
-                    write_user_files($block);
-                    write_config_file($block, $config);
+                    write_user_files($block, $rand_ports);
+                    write_config_file($block, $config, $rand_ports);
 
                     if ($Verbose) {
                         warn "sending USR1 signal to $pid.\n";
@@ -1740,8 +1752,8 @@ start_nginx:
 
             #warn "*** Restarting the nginx server...\n";
             setup_server_root($first_time);
-            write_user_files($block);
-            write_config_file($block, $config);
+            write_user_files($block, $rand_ports);
+            write_config_file($block, $config, $rand_ports);
             #warn "nginx binary: $NginxBinary";
             if (!can_run($NginxBinary)) {
                 bail_out("$name - Cannot find the nginx executable in the PATH environment");
@@ -2431,7 +2443,7 @@ request:
         }
 
         if ($i > 1) {
-            write_user_files($block);
+            write_user_files($block, $rand_ports);
         }
 
         if ($should_skip && defined $tests_to_skip) {
@@ -2516,7 +2528,7 @@ request:
             my $i = 0;
 retry:
             if (is_running($pid)) {
-                write_config_file($block, $config);
+                write_config_file($block, $config, $rand_ports);
 
                 if ($Verbose) {
                     warn "sending QUIT signal to $pid";


### PR DESCRIPTION
port conflicts occur when TEST_NGINX_USE_HUP=1 and two nearby blocks
use TEST_NGINX_RAND_PORT_XXX with the same variable name.