### PR TITLE
feature: added file name to name of the test case.

### DIFF
--- a/lib/Test/Nginx/Util.pm
+++ b/lib/Test/Nginx/Util.pm
@@ -740,6 +740,7 @@ sub run_tests () {
             $hdl->($block);
         }
 
+        $block->set_value("name", $0 . " " . $block->name);
         run_test($block);
 
         $PrevBlock = $block;


### PR DESCRIPTION
When executing test cases concurrently, you don't know which one is wrong. 

``` 
FAILED--Further testing stopped: TEST 7: ngx.exit(0) -  yield - Cannot start nginx using command "nginx -p /home/ljl/code/openresty/lua-nginx-module/t/servroot_41189/ -c /home/ljl/code/openresty/lua-nginx-module/t/servroot_41189/conf/nginx.conf > /dev/null" (status code 256).
```
