### PR TITLE
Change header matching to be case insensitive

### DIFF
--- a/lib/Test/Nginx/Socket.pm
+++ b/lib/Test/Nginx/Socket.pm
@@ -990,7 +990,7 @@ sub check_response_headers($$$$$) {
                 #warn "HIT";
                 SKIP: {
                     skip "$name - response_headers - tests skipped due to $dry_run", 1 if $dry_run;
-                    unlike $raw_headers, qr/^\s*\Q$key\E\s*:/ms,
+                    unlike $raw_headers, qr/^(?i)\s*\Q$key\E\s*:/ms,
                       "$name - header $key not present in the raw headers";
                 }
                 next;
@@ -4708,4 +4708,3 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 =head1 SEE ALSO
 
 L<Test::Nginx::Lua>, L<Test::Nginx::Lua::Stream>, L<Test::Nginx::LWP>, L<Test::Base>.
-


### PR DESCRIPTION
refs https://github.com/openresty/test-nginx/issues/126

I understand this is likely the _wrong_ fix and this should be done differently but any help in getting a proper fix/option to do case insensitive headers would be fantastic.