### PR TITLE
fix: allow capture OpenSSL version without letter

### DIFF
--- a/lib/Test/Nginx/Util.pm
+++ b/lib/Test/Nginx/Util.pm
@@ -1111,7 +1111,7 @@ sub get_nginx_version () {
         bail_out("Failed to get the version of the Nginx in PATH: $out");
     }
 
-    if ($out =~ m{built with OpenSSL (\d+)\.(\d+)\.(\d+)([a-z])}s) {
+    if ($out =~ m{built with OpenSSL (\d+)\.(\d+)\.(\d+)([a-z])?}s) {
         $OpenSSLVersion = get_canon_version_for_OpenSSL($1, $2, $3, $4);
     }
 


### PR DESCRIPTION
OpenSSL 3.0 start to use versioning without letter suffix
(https://www.openssl.org/policies/releasestrat.html).

This patch fixes the case for OpenSSL 3.0 and forks like
BoringSSL, to fix versions are falsely skipped with the
reason of "Not built with OpenSSL".