### PR TITLE
feature: add TEST_NGINX_FAST_SHUTDOWN to stop Nginx without graceful

### DIFF
--- a/lib/Test/Nginx/Socket.pm
+++ b/lib/Test/Nginx/Socket.pm
@@ -4540,6 +4540,10 @@ Defaults to 0. If set to 1, Test::Nginx module will not manage
 (configure/start/stop) the C<nginx> process. Can be useful to run tests
 against an already configured (and running) nginx server.
 
+=head2 TEST_NGINX_FAST_SHUTDOWN
+
+Defaults to 0. If set to 1, Test::Nginx module will stop C<nginx> process with SIGTERM.
+
 =head2 TEST_NGINX_NO_SHUFFLE
 
 Defaults to 0. If set to 1, will make sure the tests are run in the order

--- a/lib/Test/Nginx/Util.pm
+++ b/lib/Test/Nginx/Util.pm
@@ -635,11 +635,20 @@ sub kill_process ($$$) {
 
     if ($wait) {
         if (defined $pid) {
-            if ($Verbose) {
-                warn "sending QUIT signal to $pid";
-            }
+            if ($ENV{TEST_NGINX_FAST_SHUTDOWN}) {
+                if ($Verbose) {
+                    warn "sending TERM signal to $pid";
+                }
 
-            kill(SIGQUIT, $pid);
+                kill(SIGTERM, $pid);
+
+            } else {
+                if ($Verbose) {
+                    warn "sending QUIT signal to $pid";
+                }
+
+                kill(SIGQUIT, $pid);
+            }
         }
 
         if ($Verbose) {


### PR DESCRIPTION
Signed-off-by: spacewander <spacewanderlzx@gmail.com>