### PR TITLE
feature: valgrind: show full backtrace for lib loaded by Lua C API

### DIFF
--- a/lib/Test/Nginx/Util.pm
+++ b/lib/Test/Nginx/Util.pm
@@ -1953,7 +1953,7 @@ start_nginx:
                 my $opts;
 
                 if ($UseValgrind =~ /^\d+$/) {
-                    $opts = "--tool=memcheck --leak-check=full --show-possibly-lost=no";
+                    $opts = "--tool=memcheck --leak-check=full --keep-debuginfo=yes --show-possibly-lost=no";
 
                     if (-f 'valgrind.suppress') {
                         $cmd = "valgrind --num-callers=100 -q $opts --gen-suppressions=all --suppressions=valgrind.suppress $cmd";


### PR DESCRIPTION
keep the debuginfo so we can have a full backtrace for lib loaded by Lua C API
Signed-off-by: spacewander <spacewanderlzx@gmail.com>