### PR TITLE
Avoid breaking tests with TEST_NGINX_LOAD_MODULES

### DIFF
--- a/lib/Test/Nginx/Util.pm
+++ b/lib/Test/Nginx/Util.pm
@@ -1214,10 +1214,11 @@ sub write_config_file ($$$) {
         $main_config = '';
     }
 
+    my $load_modules_main_config = '';
     if ($LoadModules) {
         my @modules = map { "load_module $_;" } grep { $_ } split /\s+/, $LoadModules;
         if (@modules) {
-            $main_config = join " ", @modules, $main_config;
+            $load_modules_main_config = join " ", @modules;
         }
     }
 
@@ -1346,7 +1347,7 @@ _EOC_
     print $out <<_EOC_;
 #env LUA_PATH;
 #env LUA_CPATH;
-
+$load_modules_main_config
 $main_config
 
 http {


### PR DESCRIPTION
This uses an empty line to add the load_module directives, so that tests expecting an error on line 40 of nginx.conf won't break.